### PR TITLE
[IMPROVEMENT] Menu class should implement Htmlable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require-dev": {
         "orchestra/testbench": "^3.1",
-        "phpunit/phpunit": "^5.2"
+        "phpunit/phpunit": "^5.2",
+        "illuminate/contracts": "^5.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php" : "^7.0",
-        "spatie/menu": "^1.0.0"
+        "spatie/menu": "^1.0.0",
+        "illuminate/contracts": "~5.1|~5.2"
     },
     "require-dev": {
         "orchestra/testbench": "^3.1",
-        "phpunit/phpunit": "^5.2",
-        "illuminate/contracts": "^5.2"
+        "phpunit/phpunit": "^5.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -3,9 +3,10 @@
 namespace Spatie\Menu\Laravel;
 
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Contracts\Support\Htmlable;
 use Spatie\Menu\Menu as BaseMenu;
 
-class Menu extends BaseMenu
+class Menu extends BaseMenu implements Htmlable
 {
     use Macroable;
 
@@ -68,4 +69,14 @@ class Menu extends BaseMenu
     {
         return $this->add(Link::route($name, $text, $parameters, $absolute, $route));
     }
+
+    /**
+     * Get content as a string of HTML.
+     *
+     * @return string
+     */
+     public function toHtml() : string
+     {
+        return $this->render();
+     }
 }

--- a/tests/MenuTest.php
+++ b/tests/MenuTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Menu\Laravel\Test;
 
 use Spatie\Menu\Laravel\Link;
 use Spatie\Menu\Laravel\Menu;
+use Illuminate\Contracts\Support\Htmlable;
 
 class MenuTest extends TestCase
 {
@@ -24,5 +25,17 @@ class MenuTest extends TestCase
             </ul>',
             $menu
         );
+    }
+
+    /** @test */
+    function it_should_be_htmlable()
+    {
+        $menu = Menu::new()->add(Link::route('home', 'Home'));
+
+        $this->assertTrue(
+            (new \ReflectionClass($menu))->implementsInterface(Htmlable::class)
+        );
+
+        $this->assertEquals($menu->render(), $menu->toHtml());
     }
 }


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide]().
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I have added tests to prove that the code in this PR works.

---

### Description

If the Menu class implements the  `Illuminate\Contracts\Support\Htmlable` interface, it will be possible to use the standard ``{{ $var }}` syntax in Blade, as opposed to the `{!! $var !!}` syntax.

Which means you may now output the menu by doing...

```
{{ $menu }}
```

... which in my opinion looks less hacky.

This is a minor improvement, but a good one (and a simple one), in my opinion.

--

This PR does three things:

- Adds `"implements Htmlable"` to the Menu class, plus a `use` at the top,
- Adds a `toHtml` method which returns `$this->render()` to satisfy the Htmlable interface,
- Adds `illuminate/contracts` to `require-dev` in the composer.json (so that Travis doesn't fail)
- And adds a test.
