### PR TITLE
[FEATURE] Add submenuIfCan

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -196,6 +196,39 @@ class Menu extends BaseMenu implements Htmlable
     }
 
     /**
+     * @param string|array $authorization
+     * @param callable|\Spatie\Menu\Menu|\Spatie\Menu\Item $header
+     * @param callable|\Spatie\Menu\Menu|null $menu
+     *
+     * @return $this
+     */
+    public function submenuIfCan($authorization, $header, $menu = null)
+    {
+        list($authorization, $header, $menu) = $this->parseSubmenuIfCanArgs(func_get_args());
+
+        if (is_callable($menu)) {
+            $transformer = $menu;
+            $menu = $this->blueprint();
+            $transformer($menu);
+        }
+
+        if ($header instanceof Item) {
+            $header = $header->render();
+        }
+
+        return $this->addIfCan($authorization, $menu->prependIf($header, $header));
+    }
+
+    protected function parseSubmenuIfCanArgs($args): array
+    {
+        if (count($args) === 2) {
+            return [$args[0], '', $args[1]];
+        }
+
+        return [$args[0], $args[1], $args[2]];
+    }
+
+    /**
      * @return string
      */
     public function toHtml() : string

--- a/tests/AddWithPermissionsTest.php
+++ b/tests/AddWithPermissionsTest.php
@@ -136,4 +136,22 @@ class AddWithPermissionsTest extends TestCase
             Menu::new()->routeIfCan('computerSaysNo', 'home', 'Home')
         );
     }
+
+    /** @test */
+    function it_adds_a_submenu_if_the_user_has_a_certain_ability()
+    {
+        $this->assertRenders(
+            '<ul><li><a href="home">Home</a><ul><li><a href="sub">Sub</a></li></ul></li></ul>',
+            Menu::new()->submenuIfCan('computerSaysYes', Link::to('home', 'Home'), Menu::new()->link('sub', 'Sub'))
+        );
+    }
+
+    /** @test */
+    function it_doesnt_add_a_submenu_if_the_user_doesnt_have_a_certain_ability()
+    {
+        $this->assertRenders(
+            '<ul></ul>',
+            Menu::new()->submenuIfCan('computerSaysNo', Link::to('home', 'Home'), Menu::new()->link('sub', 'Sub'))
+        );
+    }
 }


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide]().
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I have added tests to prove that the code in this PR works.

---

### Description

This PR adds the `Menu::submenuIfCan` method so you could do:

```php
Menu::new()->submenuIfCan(
    'manage-users', 
    Link::to('#', 'Users'), 
    Menu::new()
        ->link('users', 'All Users')
        ->link('users/create', 'Create User')
)
```