### PR TITLE
Fix action helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All Notable changes to `laravel-menu` will be documented in this file
 
+## 2.0.1 - 2016-10-25
+
+- Fix  `Link`'s action helper so it can take the same type of parameters as the laravel `action` helper
+
 ## 2.0.0
 
 - Upgraded `spatie/menu` to 2.0.

--- a/src/Link.php
+++ b/src/Link.php
@@ -25,12 +25,12 @@ class Link extends BaseLink
     /**
      * @param string $action
      * @param string $text
-     * @param array $parameters
+     * @param mixed $parameters
      * @param bool $absolute
      *
      * @return static
      */
-    public static function toAction(string $action, string $text, array $parameters = [], bool $absolute = true)
+    public static function toAction(string $action, string $text, $parameters = [], bool $absolute = true)
     {
         return static::to(action($action, $parameters, $absolute), $text);
     }

--- a/tests/LinkTest.php
+++ b/tests/LinkTest.php
@@ -52,7 +52,16 @@ class LinkTest extends TestCase
     }
 
     /** @test */
-    public function it_can_be_created_for_an_action_with_parameters()
+    public function it_can_be_created_for_an_action_with_a_parameter()
+    {
+        $this->assertRenders(
+            '<a href="http://localhost/post/1">Post #1</a>',
+            Link::toAction(DummyController::class.'@post', 'Post #1', 1)
+        );
+    }
+
+    /** @test */
+    public function it_can_be_created_for_an_action_with_an_array_of_parameters()
     {
         $this->assertRenders(
             '<a href="http://localhost/post/1">Post #1</a>',


### PR DESCRIPTION
Fix  `Link`'s action helper so it can take the same type of parameters as the Laravel's `action` helper