### PR TITLE
Issue/108

### DIFF
--- a/tests/Issue108Test.php
+++ b/tests/Issue108Test.php
@@ -9,7 +9,10 @@ use Spatie\Menu\Laravel\Link;
 class Issue108Test extends TestCase
 {
 
-    /** @test */
+    /**
+     * @test
+     * It works in 2.9, but not in 2.10 from spatie/menu
+     */
     public function renderWithSpatieMenu2_10_2()
     {
         Menu::macro('admin', function () {

--- a/tests/Issue108Test.php
+++ b/tests/Issue108Test.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\Menu\Laravel\Test;
+
+use Spatie\Menu\Laravel\Menu;
+use Spatie\Menu\Laravel\View;
+use Spatie\Menu\Laravel\Link;
+
+class Issue108Test extends TestCase
+{
+
+    /** @test */
+    public function renderWithSpatieMenu2_10_2()
+    {
+        Menu::macro('admin', function () {
+            $menu = Menu::new();
+            $submenu = Menu::new();
+            $menu->submenu(View::create('withActive', ['active' => false]), $submenu);
+            return $menu;
+        });
+        Menu::admin()->toHtml();
+        $this->assertTrue(true);
+    }
+
+}


### PR DESCRIPTION
@see https://github.com/spatie/laravel-menu/issues/108

Laravel-menu has currently issues with spatie/menu ~ 2.10.2

Object of class Spatie\Menu\Laravel\View could not be converted to string in
vendor/spatie/menu/src/Menu.php:724

A downgrade to spatie/menu@2.9 solve it currently.