### PR TITLE
Fixed Issue - Invalid Scheme using javascript

### DIFF
--- a/src/Link.php
+++ b/src/Link.php
@@ -3,11 +3,13 @@
 namespace Spatie\Menu\Laravel;
 
 use Illuminate\Support\Traits\Macroable;
+use Spatie\Menu\Html\Attributes;
 use Spatie\Menu\Link as BaseLink;
 
 class Link extends BaseLink
 {
     use Macroable;
+
 
     /**
      * @param string $path
@@ -20,6 +22,15 @@ class Link extends BaseLink
     public static function toUrl(string $path, string $text, $parameters = [], $secure = null)
     {
         return static::to(url($path, $parameters, $secure), $text);
+    }
+
+    public static function to(string $url, string $text)
+    {
+        if (strpos($url, 'javascript:void(0);') || strpos($url, 'javascript:;')) {
+            $url = '/' . $url;
+        }
+
+        return new static($url, $text);
     }
 
     /**
@@ -50,5 +61,24 @@ class Link extends BaseLink
     public static function toRoute(string $name, string $text, $parameters = [], $absolute = true)
     {
         return static::to(route($name, $parameters, $absolute), $text);
+    }
+
+    /**
+     * @return string
+     */
+    public function render(): string
+    {
+        if (strpos($this->url, 'javascript:void(0);') || strpos($this->url, 'javascript:;')) {
+            $this->url = substr($this->url, 1);
+        }
+
+        if (filter_var($this->url, FILTER_VALIDATE_URL) && (strpos($this->url, 'javascript:void(0);') || strpos($this->url, 'javascript:;'))) {
+            $this->url = parse_url($this->url, PHP_URL_PATH);
+            $this->url = substr($this->url, 1);
+        }
+
+        $attributes = new Attributes(['href' => $this->url]);
+        $attributes->mergeWith($this->htmlAttributes);
+        return $this->prepend . "<a {$attributes}>{$this->text}</a>" . $this->append;
     }
 }

--- a/tests/LinkTest.php
+++ b/tests/LinkTest.php
@@ -77,4 +77,38 @@ class LinkTest extends TestCase
             Link::toAction(DummyController::class.'@post', 'Post #1', ['id' => 1])
         );
     }
+
+    /** @test */
+    public function it_can_be_created_for_a_url_with_javascript_operator_void()
+    {
+        $this->assertRenders(
+            '<a href="javascript:void(0);">Home</a>',
+            Link::toUrl('javascript:void(0);', 'Home')
+        );
+
+        $this->assertRenders(
+            '<a href="javascript:void(0);">Home</a>',
+            Link::to('javascript:void(0);', 'Home')
+        );
+
+        $this->assertRenders(
+            '<a href="javascript:;">Home</a>',
+            Link::toUrl('javascript:;', 'Home')
+        );
+
+        $this->assertRenders(
+            '<a href="javascript:;">Home</a>',
+            Link::to('javascript:;', 'Home')
+        );
+
+        $this->assertRenders(
+            '<a href="home">Home</a>',
+            Link::to('home', 'Home')
+        );
+
+        $this->assertRenders(
+            '<a href="other/javascript">Home</a>',
+            Link::to('other/javascript', 'Home')
+        );
+    }
 }


### PR DESCRIPTION
Fixed Issue [#99](https://github.com/spatie/laravel-menu/issues/99)

fixed problem  when I add a link method with url: `javascript:;` or `javascript:void(0);` in a Link object.