### PR TITLE
Require PHP 8+ (v4)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0, 7.4]
+                php: [8.0]
                 laravel: [7.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All Notable changes to `laravel-menu` will be documented in this file
 
+## 4.0.0 - unreleased
+- Added: PHP 8 only support
+- Changed: All syntax changed to PHP 8+
+- Removed: PHP 7.x support
+
 ## 3.7.1 - 2021-03-16
 - Support `javascript:` links
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "illuminate/auth": "^7.24|^8.0",
         "illuminate/contracts": "^7.24|^8.0",
         "illuminate/support": "^7.24|^8.0",

--- a/src/Link.php
+++ b/src/Link.php
@@ -10,21 +10,12 @@ class Link extends BaseLink
 {
     use Macroable;
 
-
-    /**
-     * @param string $path
-     * @param string $text
-     * @param mixed $parameters
-     * @param bool|null $secure
-     *
-     * @return static
-     */
-    public static function toUrl(string $path, string $text, $parameters = [], $secure = null)
+    public static function toUrl(string $path, string $text, mixed $parameters = [], bool|null $secure = null): static
     {
         return static::to(url($path, $parameters, $secure), $text);
     }
 
-    public static function to(string $url, string $text)
+    public static function to(string $url, string $text): static
     {
         if (strpos($url, 'javascript:void(0);') || strpos($url, 'javascript:;')) {
             $url = '/' . $url;
@@ -33,15 +24,7 @@ class Link extends BaseLink
         return new static($url, $text);
     }
 
-    /**
-     * @param string|array $action
-     * @param string $text
-     * @param mixed $parameters
-     * @param bool $absolute
-     *
-     * @return static
-     */
-    public static function toAction($action, string $text, $parameters = [], bool $absolute = true)
+    public static function toAction(string|array $action, string $text, mixed $parameters = [], bool $absolute = true): static
     {
         if (is_array($action)) {
             $action = implode('@', $action);
@@ -50,22 +33,11 @@ class Link extends BaseLink
         return static::to(action($action, $parameters, $absolute), $text);
     }
 
-    /**
-     * @param string $name
-     * @param string $text
-     * @param mixed $parameters
-     * @param bool $absolute
-     *
-     * @return static
-     */
-    public static function toRoute(string $name, string $text, $parameters = [], $absolute = true)
+    public static function toRoute(string $name, string $text, mixed $parameters = [], bool $absolute = true): static
     {
         return static::to(route($name, $parameters, $absolute), $text);
     }
 
-    /**
-     * @return string
-     */
     public function render(): string
     {
         if (strpos($this->url, 'javascript:void(0);') || strpos($this->url, 'javascript:;')) {

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -27,160 +27,70 @@ class Menu extends BaseMenu implements Htmlable
      *
      * @return $this
      */
-    public function setActiveFromRequest(string $requestRoot = '/')
+    public function setActiveFromRequest(string $requestRoot = '/'): self
     {
         return $this->setActive(app('request')->url(), $requestRoot);
     }
 
-    /**
-     * @param string $path
-     * @param string $text
-     * @param mixed $parameters
-     * @param bool|null $secure
-     *
-     * @return $this
-     */
-    public function url(string $path, string $text, $parameters = [], $secure = null)
+    public function url(string $path, string $text, mixed $parameters = [], bool|null $secure = null): self
     {
         return $this->add(Link::toUrl($path, $text, $parameters, $secure));
     }
 
-    /**
-     * @param string|array $action
-     * @param string $text
-     * @param mixed $parameters
-     * @param bool $absolute
-     *
-     * @return $this
-     */
-    public function action($action, string $text, $parameters = [], bool $absolute = true)
+    public function action(string|array $action, string $text, mixed $parameters = [], bool $absolute = true): self
     {
         return $this->add(Link::toAction($action, $text, $parameters, $absolute));
     }
 
-    /**
-     * @param string $name
-     * @param string $text
-     * @param mixed $parameters
-     * @param bool $absolute
-     *
-     * @return $this
-     */
-    public function route(string $name, string $text, $parameters = [], bool $absolute = true)
+    public function route(string $name, string $text, mixed $parameters = [], bool $absolute = true): self
     {
         return $this->add(Link::toRoute($name, $text, $parameters, $absolute));
     }
 
-    /**
-     * @param string $name
-     * @param array $data
-     *
-     * @return $this
-     */
-    public function view(string $name, array $data = [])
+    public function view(string $name, array $data = []): self
     {
         return $this->add(View::create($name, $data));
     }
 
-    /**
-     * @param bool $condition
-     * @param string $path
-     * @param string $text
-     * @param array $parameters
-     * @param bool|null $secure
-     *
-     * @return $this
-     */
-    public function urlIf($condition, string $path, string $text, array $parameters = [], $secure = null)
+    public function urlIf(bool $condition, string $path, string $text, array $parameters = [], bool|null $secure = null): self
     {
         return $this->addIf($condition, Link::toUrl($path, $text, $parameters, $secure));
     }
 
-    /**
-     * @param bool $condition
-     * @param string|array $action
-     * @param string $text
-     * @param array $parameters
-     * @param bool $absolute
-     *
-     * @return $this
-     */
-    public function actionIf($condition, $action, string $text, array $parameters = [], bool $absolute = true)
+    public function actionIf(bool $condition, string|array $action, string $text, array $parameters = [], bool $absolute = true): self
     {
         return $this->addIf($condition, Link::toAction($action, $text, $parameters, $absolute));
     }
 
-    /**
-     * @param bool $condition
-     * @param string $name
-     * @param string $text
-     * @param array $parameters
-     * @param bool $absolute
-     *
-     * @return $this
-     */
-    public function routeIf($condition, string $name, string $text, array $parameters = [], bool $absolute = true)
+    public function routeIf(bool $condition, string $name, string $text, array $parameters = [], bool $absolute = true): self
     {
         return $this->addIf($condition, Link::toRoute($name, $text, $parameters, $absolute));
     }
 
-    /**
-     * @param $condition
-     * @param string $name
-     * @param array $data
-     *
-     * @return $this
-     */
-    public function viewIf($condition, string $name, array $data = null)
+    public function viewIf($condition, string $name, array|null $data = null): self
     {
         return $this->addIf($condition, View::create($name, $data));
     }
 
-    /**
-     * @param string|array $authorization
-     * @param \Spatie\Menu\Item $item
-     *
-     * @return $this
-     */
-    public function addIfCan($authorization, Item $item)
+    public function addIfCan(string|array $authorization, Item $item): self
     {
-        $ablityArguments = is_array($authorization) ? $authorization : [$authorization];
-        $ability = array_shift($ablityArguments);
+        $abilityArguments = is_array($authorization) ? $authorization : [$authorization];
+        $ability = array_shift($abilityArguments);
 
-        return $this->addIf(app(Gate::class)->allows($ability, $ablityArguments), $item);
+        return $this->addIf(app(Gate::class)->allows($ability, $abilityArguments), $item);
     }
 
-    /**
-     * @param string|array $authorization
-     * @param string $url
-     * @param string $text
-     *
-     * @return $this
-     */
-    public function linkIfCan($authorization, string $url, string $text)
+    public function linkIfCan(string|array $authorization, string $url, string $text): self
     {
         return $this->addIfCan($authorization, Link::to($url, $text));
     }
 
-    /**
-     * @param string|array $authorization
-     * @param string $html
-     *
-     * @return \Spatie\Menu\Laravel\Menu
-     */
-    public function htmlIfCan($authorization, string $html)
+    public function htmlIfCan(string|array $authorization, string $html): Menu
     {
         return $this->addIfCan($authorization, Html::raw($html));
     }
 
-    /**
-     * @param string|array $authorization
-     * @param callable|\Spatie\Menu\Menu|\Spatie\Menu\Item $header
-     * @param callable|\Spatie\Menu\Menu|null $menu
-     *
-     * @return $this
-     */
-    public function submenuIfCan($authorization, $header, $menu = null)
+    public function submenuIfCan(string|array $authorization, callable|BaseMenu|Item $header, callable|BaseMenu|null $menu = null): self
     {
         [$authorization, $header, $menu] = $this->parseSubmenuIfCanArgs(...func_get_args());
 
@@ -195,64 +105,29 @@ class Menu extends BaseMenu implements Htmlable
         return array_merge([$authorization], $this->parseSubmenuArgs($args));
     }
 
-    /**
-     * @param string|array $authorization
-     * @param string $path
-     * @param string $text
-     * @param array $parameters
-     * @param bool|null $secure
-     *
-     * @return $this
-     */
-    public function urlIfCan($authorization, string $path, string $text, array $parameters = [], $secure = null)
+    public function urlIfCan(string|array $authorization, string $path, string $text, array $parameters = [], bool|null $secure = null): self
     {
         return $this->addIfCan($authorization, Link::toUrl($path, $text, $parameters, $secure));
     }
 
-    /**
-     * @param string|array $authorization
-     * @param string|array $action
-     * @param string $text
-     * @param array $parameters
-     * @param bool $absolute
-     *
-     * @return $this
-     */
-    public function actionIfCan($authorization, $action, string $text, array $parameters = [], bool $absolute = true)
+    public function actionIfCan(string|array $authorization, string|array $action, string $text, array $parameters = [], bool $absolute = true): self
     {
         return $this->addIfCan($authorization, Link::toAction($action, $text, $parameters, $absolute));
     }
 
-    /**
-     * @param string|array $authorization
-     * @param string $name
-     * @param string $text
-     * @param array $parameters
-     * @param bool $absolute
-     *
-     * @return $this
-     */
-    public function routeIfCan($authorization, string $name, string $text, array $parameters = [], bool $absolute = true)
+    public function routeIfCan(string|array $authorization, string $name, string $text, array $parameters = [], bool $absolute = true): self
     {
         return $this->addIfCan($authorization, Link::toRoute($name, $text, $parameters, $absolute));
     }
 
     /**
-     * @param $authorization
-     * @param string $name
-     * @param array $data
-     *
-     * @return $this
      * @internal param $condition
      */
-    public function viewIfCan($authorization, string $name, array $data = null)
+    public function viewIfCan(string|array $authorization, string $name, array|null $data = null): self
     {
         return $this->addIfCan($authorization, View::create($name, $data));
     }
 
-    /**
-     * @return string
-     */
     public function toHtml(): string
     {
         return $this->render();

--- a/src/View.php
+++ b/src/View.php
@@ -14,35 +14,20 @@ class View implements Item, Activatable, HasParentAttributes
 {
     use ActivatableTrait, Macroable, HasParentAttributesTrait;
 
-    /** @var string */
-    protected $name;
+    protected string|null $url = null;
 
-    /** @var array */
-    protected $data;
+    protected bool $active = false;
 
-    /** @var string|null */
-    protected $url = null;
+    protected Attributes $parentAttributes;
 
-    /** @var bool */
-    protected $active = false;
-
-    /** @var Attributes */
-    protected $parentAttributes;
-
-    public function __construct(string $name, array $data = [])
-    {
-        $this->name = $name;
-        $this->data = $data;
+    public function __construct(
+        protected string $name,
+        protected array $data = [],
+    ) {
         $this->parentAttributes = new Attributes();
     }
 
-    /**
-     * @param string $name
-     * @param array $data
-     *
-     * @return static
-     */
-    public static function create(string $name, array $data = [])
+    public static function create(string $name, array $data = []): static
     {
         $view = new static($name, $data);
 
@@ -53,9 +38,6 @@ class View implements Item, Activatable, HasParentAttributes
         return $view;
     }
 
-    /**
-     * @return string
-     */
     public function render(): string
     {
         return view($this->name)


### PR DESCRIPTION
This PR adds a new major version, v4.0.0.  

Specifically, it:

- Removes support for all PHP 7.x versions.
- Requires PHP 8.0+.
- All syntax converted to PHP 8 where possible.
- Removed unnecessary PHP docblocks per [Spatie's guidelines](https://spatie.be/guidelines/laravel-php#docblocks).
- _Updates the changelog - release date needs to be updated, currently is "unreleased"._

Resolves #113.