### PR TITLE
Update spatie/menu dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/auth": "^7.24|^8.0",
         "illuminate/contracts": "^7.24|^8.0",
         "illuminate/support": "^7.24|^8.0",
-        "spatie/menu": "^2.8"
+        "spatie/menu": "^3.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9",


### PR DESCRIPTION
This is related to https://github.com/spatie/menu/pull/137, this updates the `spatie/menu` dependency to 3.0. I think this can be merged without any backwards compatibility changes.